### PR TITLE
chore(ci): add waitlist batch rollout workflow

### DIFF
--- a/.github/workflows/waitlist-batch-rollout.yml
+++ b/.github/workflows/waitlist-batch-rollout.yml
@@ -1,0 +1,110 @@
+name: Waitlist Batch Rollout
+
+on:
+  workflow_dispatch:
+    inputs:
+      phase:
+        description: Rollout phase
+        required: true
+        type: choice
+        default: t0
+        options:
+          - t0
+          - t3
+          - t7
+      dry_run:
+        description: Dry run (no webhook call)
+        required: true
+        type: boolean
+        default: true
+  schedule:
+    - cron: "0 1 7 4 *"
+    - cron: "0 1 10 4 *"
+    - cron: "0 1 14 4 *"
+
+concurrency:
+  group: waitlist-batch-rollout-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  rollout:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      WAITLIST_BATCH_WEBHOOK_URL: ${{ secrets.WAITLIST_BATCH_WEBHOOK_URL }}
+      WAITLIST_BATCH_WEBHOOK_TOKEN: ${{ secrets.WAITLIST_BATCH_WEBHOOK_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Resolve phase
+        id: phase
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            phase="${{ inputs.phase }}"
+          else
+            day="$(date -u +%d)"
+            case "$day" in
+              07) phase="t0" ;;
+              10) phase="t3" ;;
+              14) phase="t7" ;;
+              *)
+                echo "Scheduled run on unsupported day=$day; exiting"
+                echo "skip=true" >> "$GITHUB_OUTPUT"
+                exit 0
+                ;;
+            esac
+          fi
+
+          echo "phase=$phase" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Guard target year
+        if: ${{ steps.phase.outputs.skip == 'false' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          current_year="$(date -u +%Y)"
+          if [ "$current_year" != "2026" ] && [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
+            echo "This rollout schedule is pinned to 2026. current_year=$current_year"
+            exit 1
+          fi
+
+      - name: Trigger waitlist batch
+        if: ${{ steps.phase.outputs.skip == 'false' }}
+        id: trigger
+        env:
+          WAITLIST_BATCH_PHASE: ${{ steps.phase.outputs.phase }}
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
+        run: node scripts/waitlist/trigger-batch.mjs | tee waitlist-batch-result.json
+
+      - name: Upload execution artifact
+        if: ${{ steps.phase.outputs.skip == 'false' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: waitlist-batch-${{ steps.phase.outputs.phase }}-${{ github.run_id }}
+          path: waitlist-batch-result.json
+
+      - name: Add run summary
+        if: ${{ steps.phase.outputs.skip == 'false' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "## Waitlist Batch Rollout"
+            echo ""
+            echo "- Phase: \\`${{ steps.phase.outputs.phase }}\\`"
+            echo "- Dry run: \\`${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}\\`"
+            echo "- Idempotency key: \\`${{ steps.trigger.outputs.idempotency_key }}\\`"
+            echo "- Schedule (UTC): \\`${{ steps.trigger.outputs.scheduled_utc }}\\`"
+            echo "- Schedule (KST): \\`${{ steps.trigger.outputs.scheduled_kst }}\\`"
+            echo "- Run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/waitlist/trigger-batch.mjs
+++ b/scripts/waitlist/trigger-batch.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from "node:url";
+
+const PHASE_SCHEDULE = {
+  t0: {
+    kst: "2026-04-07T10:00:00+09:00",
+    utc: "2026-04-07T01:00:00Z",
+  },
+  t3: {
+    kst: "2026-04-10T10:00:00+09:00",
+    utc: "2026-04-10T01:00:00Z",
+  },
+  t7: {
+    kst: "2026-04-14T10:00:00+09:00",
+    utc: "2026-04-14T01:00:00Z",
+  },
+};
+
+const PHASES = new Set(Object.keys(PHASE_SCHEDULE));
+
+function readRequiredEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+function readPhase() {
+  const raw = (process.env.WAITLIST_BATCH_PHASE ?? "").toLowerCase();
+  if (!PHASES.has(raw)) {
+    throw new Error(
+      `WAITLIST_BATCH_PHASE must be one of: ${[...PHASES].join(", ")}; got '${raw || "<empty>"}'`
+    );
+  }
+  return raw;
+}
+
+function toBoolean(raw, defaultValue = false) {
+  if (raw == null) {
+    return defaultValue;
+  }
+  return ["1", "true", "yes", "on"].includes(raw.trim().toLowerCase());
+}
+
+export function buildPayload({ phase, runId, repository, sha }) {
+  const schedule = PHASE_SCHEDULE[phase];
+  const idempotencyKey = `waitlist-${phase}-${schedule.utc}`;
+
+  return {
+    phase,
+    schedule,
+    idempotencyKey,
+    flags: {
+      "app.delivery.t0_enabled": true,
+      "ui.modals.whats_new_enabled": true,
+      "comms.waitlist_batch_enabled": true,
+      "app.delivery.rollback_enabled": false,
+    },
+    source: {
+      provider: "github-actions",
+      runId,
+      repository,
+      sha,
+    },
+    requestedAt: new Date().toISOString(),
+  };
+}
+
+async function postBatch(url, token, payload) {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      "Idempotency-Key": payload.idempotencyKey,
+    },
+    body: JSON.stringify(payload),
+  });
+
+  const body = await response.text();
+  if (!response.ok) {
+    throw new Error(`Batch trigger failed (${response.status}): ${body}`);
+  }
+
+  return {
+    status: response.status,
+    body,
+  };
+}
+
+export async function main() {
+  const phase = readPhase();
+  const dryRun = toBoolean(process.env.DRY_RUN, false);
+  const runId = process.env.GITHUB_RUN_ID ?? "local";
+  const repository = process.env.GITHUB_REPOSITORY ?? "local";
+  const sha = process.env.GITHUB_SHA ?? "local";
+
+  const payload = buildPayload({ phase, runId, repository, sha });
+
+  if (process.env.GITHUB_OUTPUT) {
+    const output = process.env.GITHUB_OUTPUT;
+    const fs = await import("node:fs/promises");
+    await fs.appendFile(output, `idempotency_key=${payload.idempotencyKey}\n`);
+    await fs.appendFile(output, `scheduled_utc=${payload.schedule.utc}\n`);
+    await fs.appendFile(output, `scheduled_kst=${payload.schedule.kst}\n`);
+  }
+
+  if (dryRun) {
+    console.log(JSON.stringify({ dryRun: true, payload }, null, 2));
+    return;
+  }
+
+  const webhookUrl = readRequiredEnv("WAITLIST_BATCH_WEBHOOK_URL");
+  const webhookToken = process.env.WAITLIST_BATCH_WEBHOOK_TOKEN ?? "";
+
+  const result = await postBatch(webhookUrl, webhookToken, payload);
+  console.log(
+    JSON.stringify(
+      {
+        dryRun: false,
+        status: result.status,
+        payload,
+        responseBody: result.body,
+      },
+      null,
+      2
+    )
+  );
+}
+
+const isCliInvocation =
+  process.argv[1] != null &&
+  import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isCliInvocation) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

- add  for scheduled/manual batch rollout dispatch
- add  helper used by workflow

## Notes

- workflow is currently set for 2026 demo schedule (t0/t3/t7)
- keep PR scope to waitlist rollout publication path as requested by GAM-369

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 위시리스트 배치 롤아웃 자동화 시스템이 추가되었습니다. 정기적으로 스케줄된 시간에 자동 실행되거나 필요시 수동으로 트리거할 수 있습니다. 테스트 모드를 지원하여 실제 배포 전에 검증할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->