### PR TITLE
feat: add video interviews and cohort reports

### DIFF
--- a/app.json
+++ b/app.json
@@ -15,7 +15,8 @@
       "bundleIdentifier": "com.bongsub.aiaptitudegames",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
-        "NSCameraUsageDescription": "모의 면접 영상 답변을 위해 카메라 접근이 필요해요."
+        "NSCameraUsageDescription": "모의 면접 영상 답변을 위해 카메라 접근이 필요해요.",
+        "NSMicrophoneUsageDescription": "모의 면접 영상 답변 녹음을 위해 마이크 접근이 필요해요."
       },
       "appleTeamId": "Z995BAAVG5"
     },
@@ -44,7 +45,7 @@
         "expo-camera",
         {
           "cameraPermission": "모의 면접 영상 답변을 위해 카메라 접근이 필요해요.",
-          "recordAudioAndroid": false
+          "recordAudioAndroid": true
         }
       ],
       [
@@ -53,7 +54,8 @@
           "microphonePermission": "면접 답변 녹음을 위해 마이크 접근이 필요해요."
         }
       ],
-      "expo-asset"
+      "expo-asset",
+      "expo-video"
     ]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "expo-splash-screen": "~56.0.10",
         "expo-sqlite": "~56.0.5",
         "expo-status-bar": "~56.0.4",
+        "expo-video": "~56.1.3",
         "expo-web-browser": "~56.0.5",
         "lucide-react-native": "^1.17.0",
         "react": "19.2.3",
@@ -7177,6 +7178,17 @@
       "license": "MIT",
       "peerDependencies": {
         "expo": "*"
+      }
+    },
+    "node_modules/expo-video": {
+      "version": "56.1.3",
+      "resolved": "https://registry.npmjs.org/expo-video/-/expo-video-56.1.3.tgz",
+      "integrity": "sha512-Ht2BMdx11RnGKxILL/P4t/hl4kqWXq1vLaoOrLZlDed+IXgf8hdDI9jmtEEgsIHwf3jaHFXblJCRVuS9mIxKAw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-web-browser": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "expo-splash-screen": "~56.0.10",
     "expo-sqlite": "~56.0.5",
     "expo-status-bar": "~56.0.4",
+    "expo-video": "~56.1.3",
     "expo-web-browser": "~56.0.5",
     "lucide-react-native": "^1.17.0",
     "react": "19.2.3",

--- a/src/components/interview/InterviewAnalysisBody.tsx
+++ b/src/components/interview/InterviewAnalysisBody.tsx
@@ -102,6 +102,32 @@ export function InterviewAnalysisBody({ interview }: InterviewAnalysisBodyProps)
         </Card>
       </VStack>
 
+      {interview.delivery_details && interview.delivery_details.length > 0 ? (
+        <VStack gap="x2">
+          <SectionHead title="전달력 세부" />
+          <Card>
+            <List.Root>
+              {interview.delivery_details.map((detail, index) => (
+                <Fragment key={index}>
+                  {index > 0 ? <List.Divider /> : null}
+                  <HStack align="center" gap="x3" py="x2">
+                    <Box width="x16">
+                      <Text textStyle="t3Medium" maxLines={2}>
+                        {detail.label}
+                      </Text>
+                    </Box>
+                    <Box flex={1}>
+                      <ProgressBar value={detail.value} layout="inline" />
+                    </Box>
+                    <Text textStyle="t5Bold">{detail.value}</Text>
+                  </HStack>
+                </Fragment>
+              ))}
+            </List.Root>
+          </Card>
+        </VStack>
+      ) : null}
+
       {interview.ncs_units.length > 0 ? (
         <VStack gap="x2">
           <SectionHead title="NCS 능력단위" />

--- a/src/components/interview/InterviewFlowParts.tsx
+++ b/src/components/interview/InterviewFlowParts.tsx
@@ -1,6 +1,7 @@
-import { type ReactNode } from 'react';
+import { type ReactNode, type RefObject } from 'react';
 import { Linking, Pressable } from 'react-native';
 import { CameraView, useCameraPermissions } from 'expo-camera';
+import { useVideoPlayer, VideoView } from 'expo-video';
 
 import { Button } from '../ui/Button';
 import { Card } from '../ui/Card';
@@ -11,8 +12,10 @@ import { Box } from '../../design-system/components/Box';
 import { Grid } from '../../design-system/components/Grid';
 import { HStack, VStack } from '../../design-system/components/Stack';
 import { Text } from '../../design-system/components/Text';
+import { useDesignSystemTheme } from '../../design-system/provider';
 import { INTERVIEW_STEPS, STAR_GUIDE } from '../../data/interviewFlow';
 import type { InterviewStepKey } from '../../data/interviewFlow';
+import type { MediaKind } from '../../domain/interviewMedia';
 import type { IconName } from '../../shared/types';
 
 
@@ -162,26 +165,43 @@ export function formatRecordTime(seconds: number) {
 export function InterviewCameraView({
   active,
   recording,
+  reviewing,
   elapsed,
+  kind,
+  cameraRef,
+  reviewUri,
 }: {
   active: boolean;
   recording: boolean;
+  reviewing: boolean;
   elapsed: number;
+  kind: MediaKind;
+  cameraRef: RefObject<CameraView | null>;
+  reviewUri: string | null;
 }) {
   const [permission, requestPermission] = useCameraPermissions();
   const canShowCamera = active && permission?.granted;
+  const showVideoReview = kind === 'video' && reviewing && reviewUri != null;
 
   return (
     <Box bg="bg.neutralSolid" borderRadius="r3" height={cameraPreviewHeight} overflow="hidden" width={cameraPreviewWidth}>
-      {canShowCamera ? (
+      {showVideoReview ? (
+        <VideoReviewView uri={reviewUri} />
+      ) : canShowCamera ? (
         <Box flex={1}>
-          <CameraView facing="front" active={active} />
+          <CameraView
+            ref={cameraRef}
+            facing="front"
+            mode={kind === 'video' ? 'video' : 'picture'}
+            videoQuality={kind === 'video' ? '720p' : undefined}
+            active={active}
+          />
         </Box>
       ) : (
         <VStack align="center" flex={1} gap="x2" justify="center" p="x2">
           <Icon name="Video" color="fg.neutralInverted" />
           <Text align="center" color="fg.neutralInverted" textStyle="t1Regular">
-            카메라 권한이 필요해요
+            {kind === 'video' ? '카메라·마이크 권한이 필요해요' : '카메라 권한이 필요해요'}
           </Text>
           {permission?.canAskAgain ? (
             <Button label="허용" size="small" variant="weak" onPress={requestPermission} />
@@ -200,6 +220,17 @@ export function InterviewCameraView({
       ) : null}
     </Box>
   );
+}
+
+function VideoReviewView({ uri }: { uri: string }) {
+  const { theme } = useDesignSystemTheme();
+  const player = useVideoPlayer(uri, (instance) => {
+    instance.loop = false;
+  });
+  const width = theme.dimension.x[cameraPreviewWidth];
+  const height = theme.dimension.x[cameraPreviewHeight];
+
+  return <VideoView player={player} style={{ width, height }} />;
 }
 
 export type RecordMode = 'ready' | 'rec' | 'review';

--- a/src/components/interview/InterviewSetupView.tsx
+++ b/src/components/interview/InterviewSetupView.tsx
@@ -15,12 +15,14 @@ import { Text } from '../../design-system/components/Text';
 import { useJobPostingCatalog, useMyJobPostings, type JobPostingRow } from '../../data/server/useJobPostings';
 import { useResumes, type ResumeRow } from '../../data/server/useResumes';
 import { jobFamilyLabel } from '../../domain/jobFamily';
+import type { MediaKind } from '../../domain/interviewMedia';
 
 const PICKER_CARD_HEIGHT = 'x16';
 
 export type InterviewSetupViewProps = {
   selectedPosting: JobPostingRow | null;
   selectedResume: ResumeRow | null;
+  mediaKind: MediaKind;
   micDenied: boolean;
   canAskMicAgain: boolean;
   starting: boolean;
@@ -33,6 +35,7 @@ export type InterviewSetupViewProps = {
 export function InterviewSetupView({
   selectedPosting,
   selectedResume,
+  mediaKind,
   micDenied,
   canAskMicAgain,
   starting,
@@ -143,7 +146,11 @@ export function InterviewSetupView({
           </VStack>
 
           {micDenied ? (
-            <MicPermissionCard canAskAgain={canAskMicAgain} onRequestAgain={onRequestMicAgain} />
+            <MicPermissionCard
+              mediaKind={mediaKind}
+              canAskAgain={canAskMicAgain}
+              onRequestAgain={onRequestMicAgain}
+            />
           ) : null}
         </VStack>
       </Body>
@@ -290,25 +297,36 @@ function PickerRow({
 }
 
 function MicPermissionCard({
+  mediaKind,
   canAskAgain,
   onRequestAgain,
 }: {
+  mediaKind: MediaKind;
   canAskAgain: boolean;
   onRequestAgain: () => void;
 }) {
+  const isVideo = mediaKind === 'video';
   return (
     <Card bg="palette.yellow100" borderColor="stroke.neutralSubtle" p="x3" gap="x2">
       <HStack align="center" gap="x2">
-        <Icon name="Mic" color="fg.warning" />
-        <Text textStyle="t4Bold">마이크 권한이 필요해요</Text>
+        <Icon name={isVideo ? 'Video' : 'Mic'} color="fg.warning" />
+        <Text textStyle="t4Bold">{isVideo ? '카메라·마이크 권한이 필요해요' : '마이크 권한이 필요해요'}</Text>
       </HStack>
       <Text color="fg.neutralMuted" textStyle="t3Regular">
-        답변을 녹음하려면 마이크 접근을 허용해 주세요.
+        {isVideo
+          ? '영상 답변을 녹화하려면 카메라·마이크 접근을 허용해 주세요.'
+          : '답변을 녹음하려면 마이크 접근을 허용해 주세요.'}
       </Text>
       <HStack gap="x2">
         {canAskAgain ? (
           <Box flex={1}>
-            <Button label="허용 다시 요청" variant="outline" iconLeft="Mic" fullWidth onPress={onRequestAgain} />
+            <Button
+              label="허용 다시 요청"
+              variant="outline"
+              iconLeft={isVideo ? 'Video' : 'Mic'}
+              fullWidth
+              onPress={onRequestAgain}
+            />
           </Box>
         ) : (
           <Box flex={1}>

--- a/src/components/profile/BirthYearBandSheet.tsx
+++ b/src/components/profile/BirthYearBandSheet.tsx
@@ -1,0 +1,114 @@
+import { Pressable } from 'react-native';
+
+import { Sheet } from '../app/Sheet';
+import { Icon } from '../ui/Icon';
+import { useUpdateProfile } from '../../data/server/useProfile';
+import { Box } from '../../design-system/components/Box';
+import { HStack, VStack } from '../../design-system/components/Stack';
+import { Text } from '../../design-system/components/Text';
+import { BIRTH_YEAR_BAND_OPTIONS, type BirthYearBand } from '../../domain/birthYearBand';
+
+export type BirthYearBandSheetProps = {
+  visible: boolean;
+  current: BirthYearBand | null;
+  onClose: () => void;
+};
+
+export function BirthYearBandSheet({ visible, current, onClose }: BirthYearBandSheetProps) {
+  const updateProfile = useUpdateProfile();
+
+  function handleSelect(band: BirthYearBand) {
+    if (updateProfile.isPending) return;
+    if (band === current) {
+      onClose();
+      return;
+    }
+    updateProfile.mutate(
+      { birthYearBand: band, birthYearBandConsentAt: new Date().toISOString() },
+      { onSuccess: onClose },
+    );
+  }
+
+  function handleClear() {
+    if (updateProfile.isPending) return;
+    if (current == null) {
+      onClose();
+      return;
+    }
+    updateProfile.mutate(
+      { birthYearBand: null, birthYearBandConsentAt: null },
+      { onSuccess: onClose },
+    );
+  }
+
+  return (
+    <Sheet
+      visible={visible}
+      title="출생 연도"
+      subtitle="또래와 비교한 리포트를 보여드릴 때 사용해요. 언제든 비공개로 바꿀 수 있어요."
+      onClose={onClose}
+    >
+      <VStack gap="x2">
+        {BIRTH_YEAR_BAND_OPTIONS.map((option) => {
+          const selected = option.value === current;
+          return (
+            <Pressable
+              key={option.value}
+              accessibilityRole="radio"
+              accessibilityState={{ selected, disabled: updateProfile.isPending }}
+              disabled={updateProfile.isPending}
+              onPress={() => handleSelect(option.value)}
+            >
+              <HStack
+                align="center"
+                bg={selected ? 'bg.brandWeak' : 'bg.layerFloating'}
+                borderColor={selected ? 'stroke.brandWeak' : 'stroke.neutralWeak'}
+                borderRadius="r3"
+                borderWidth="thin"
+                gap="x3"
+                p="x3"
+              >
+                <Box flex={1}>
+                  <Text color={selected ? 'fg.brand' : 'fg.neutral'} textStyle="t4Bold">
+                    {option.label}
+                  </Text>
+                </Box>
+                <Icon
+                  name={selected ? 'CircleDot' : 'Circle'}
+                  color={selected ? 'fg.brand' : 'fg.neutralSubtle'}
+                />
+              </HStack>
+            </Pressable>
+          );
+        })}
+
+        <Pressable
+          accessibilityRole="radio"
+          accessibilityState={{ selected: current == null, disabled: updateProfile.isPending }}
+          disabled={updateProfile.isPending}
+          onPress={handleClear}
+        >
+          <HStack
+            align="center"
+            bg={current == null ? 'bg.brandWeak' : 'bg.layerFloating'}
+            borderColor={current == null ? 'stroke.brandWeak' : 'stroke.neutralWeak'}
+            borderRadius="r3"
+            borderWidth="thin"
+            gap="x3"
+            p="x3"
+          >
+            <Box flex={1}>
+              <Text color={current == null ? 'fg.brand' : 'fg.neutral'} textStyle="t4Bold">
+                선택 안 함 (비공개)
+              </Text>
+            </Box>
+            <Icon
+              name={current == null ? 'CircleDot' : 'Circle'}
+              color={current == null ? 'fg.brand' : 'fg.neutralSubtle'}
+            />
+          </HStack>
+        </Pressable>
+      </VStack>
+    </Sheet>
+  );
+}

--- a/src/components/reports/ReportCharts.tsx
+++ b/src/components/reports/ReportCharts.tsx
@@ -7,6 +7,7 @@ import { HStack, VStack } from '../../design-system/components/Stack';
 import { Text } from '../../design-system/components/Text';
 import { resolveColor } from '../../design-system/components/style-props';
 import { useDesignSystemTheme } from '../../design-system/provider';
+import type { ReportResponsePatternScale } from '../../domain/report';
 import {
   Canvas,
   Circle,
@@ -27,14 +28,6 @@ type ChartSize = { width: number; height: number };
 type Point = { x: number; y: number };
 
 const EMPTY_SIZE = { width: 0, height: 0 };
-const RESPONSE_PATTERN_POINTS = [
-  { id: 'baseline-1', x: 0.45, y: 0.6 },
-  { id: 'baseline-2', x: 0.52, y: 0.55 },
-  { id: 'baseline-3', x: 0.58, y: 0.48 },
-  { id: 'baseline-4', x: 0.48, y: 0.52 },
-  { id: 'baseline-5', x: 0.55, y: 0.5 },
-  { id: 'baseline-6', x: 0.5, y: 0.57 },
-] as const;
 const BULLET_BAR_TOKENS = {
   trackHeight: 'x1_5',
   markerHeight: 'x3',
@@ -161,9 +154,10 @@ export function BulletBar({ value, peerMedian = null }: BulletBarProps) {
 
 export type StressResilienceChartProps = {
   values: number[];
+  warningBand?: { start: number; end: number } | null;
 };
 
-export function StressResilienceChart({ values }: StressResilienceChartProps) {
+export function StressResilienceChart({ values, warningBand }: StressResilienceChartProps) {
   const { theme } = useDesignSystemTheme();
   const { size, onLayout } = useMeasuredChart();
   const progress = useFocusProgress();
@@ -175,8 +169,8 @@ export function StressResilienceChart({ values }: StressResilienceChartProps) {
     return { x, y };
   });
   const path = buildPolylinePath(points);
-  const bandX = size.width * 0.46;
-  const bandWidth = size.width * 0.18;
+  const bandX = warningBand ? size.width * warningBand.start : 0;
+  const bandWidth = warningBand ? size.width * (warningBand.end - warningBand.start) : 0;
 
   return (
     <Box accessibilityRole="image" height={120} onLayout={onLayout} width="full">
@@ -184,7 +178,9 @@ export function StressResilienceChart({ values }: StressResilienceChartProps) {
         {size.width > 0 ? (
           <>
             <RoundedRect x={0} y={0} width={size.width} height={size.height} r={12} color={resolveColor(theme, 'bg.neutralWeak')} />
-            <Rect x={bandX} y={8} width={bandWidth} height={size.height - 16} color={warningBg} />
+            {warningBand ? (
+              <Rect x={bandX} y={8} width={bandWidth} height={size.height - 16} color={warningBg} />
+            ) : null}
             <Path
               path={path}
               color={brandColor}
@@ -202,41 +198,81 @@ export function StressResilienceChart({ values }: StressResilienceChartProps) {
   );
 }
 
-export function ResponsePatternChart() {
+// One bipolar scale: neutral full-width track, a center tick at 50%, and ONE
+// neutral marker positioned at `value`% (성향, not 우열 — never brand/positive/critical).
+// Mirrors BulletBar's clamp/measure/useDerivedValue pattern; only the marker x is
+// animated (transform-safe).
+function PatternTrack({ value }: { value: number }) {
   const { theme } = useDesignSystemTheme();
   const { size, onLayout } = useMeasuredChart();
-  const progress = useFocusProgress(450);
-  const brandColor = resolveColor(theme, 'bg.brandSolid');
-  const gridColor = resolveColor(theme, 'stroke.neutralWeak');
-  const pointColor = resolveColor(theme, 'fg.neutralSubtle');
-  const activeRadius = useDerivedValue(() => 4 + progress.value * 6, []);
+  const progress = useFocusProgress(400);
+  const clamped = clamp(value);
+  const trackColor = resolveColor(theme, 'bg.neutralWeak');
+  const tickColor = resolveColor(theme, 'stroke.neutralWeak');
+  const markerColor = resolveColor(theme, 'fg.neutral');
+  const trackHeight = theme.dimension.x[BULLET_BAR_TOKENS.trackHeight];
+  const markerHeight = theme.dimension.x[BULLET_BAR_TOKENS.markerHeight];
+  const markerWidth = theme.dimension.x[BULLET_BAR_TOKENS.markerWidth];
+  const trackRadius = theme.radius[BULLET_BAR_TOKENS.radius];
+  const trackY = (markerHeight - trackHeight) / 2;
+  const markerMax = Math.max(0, size.width - markerWidth);
+  const tickX = Math.max(0, Math.min(markerMax, size.width / 2 - markerWidth / 2));
+  const markerX = useDerivedValue(
+    () => clamp((size.width * clamped) / 100 * progress.value, 0, markerMax),
+    [size.width, clamped, markerMax],
+  );
 
   return (
-    <VStack gap="x2">
-      <Box accessibilityRole="image" height={210} onLayout={onLayout} width="full">
-        <Canvas style={{ width: '100%', height: '100%' }}>
-          {size.width > 0 ? (
-            <>
-              <RoundedRect x={0} y={0} width={size.width} height={size.height} r={12} color={resolveColor(theme, 'bg.neutralWeak')} />
-              <Path path={buildPolylinePath([{ x: size.width / 2, y: 12 }, { x: size.width / 2, y: size.height - 12 }])} color={gridColor} style="stroke" strokeWidth={1} />
-              <Path path={buildPolylinePath([{ x: 12, y: size.height / 2 }, { x: size.width - 12, y: size.height / 2 }])} color={gridColor} style="stroke" strokeWidth={1} />
-              {RESPONSE_PATTERN_POINTS.map((point) => (
-                <Circle
-                  key={point.id}
-                  cx={point.x * size.width}
-                  cy={point.y * size.height}
-                  r={4}
-                  color={pointColor}
-                />
-              ))}
-              <Circle cx={0.68 * size.width} cy={0.28 * size.height} r={activeRadius} color={brandColor} />
-            </>
-          ) : null}
-        </Canvas>
-      </Box>
-      <Text align="center" color="fg.brand" textStyle="t4Bold">
-        통찰형 직관 결정가
-      </Text>
+    <Box
+      accessibilityRole="progressbar"
+      accessibilityValue={{ min: 0, max: 100, now: clamped }}
+      flex={1}
+      height={markerHeight}
+      onLayout={onLayout}
+      width="full"
+    >
+      <Canvas style={{ width: '100%', height: '100%' }}>
+        {size.width > 0 ? (
+          <>
+            <RoundedRect
+              x={0}
+              y={trackY}
+              width={size.width}
+              height={trackHeight}
+              r={trackRadius}
+              color={trackColor}
+            />
+            <Rect x={tickX} y={0} width={markerWidth} height={markerHeight} color={tickColor} />
+            <Rect x={markerX} y={0} width={markerWidth} height={markerHeight} color={markerColor} />
+          </>
+        ) : null}
+      </Canvas>
+    </Box>
+  );
+}
+
+export function ResponsePatternRows({ scales }: { scales: ReportResponsePatternScale[] }) {
+  return (
+    <VStack gap="x4">
+      {scales.map((scale) => (
+        <VStack key={scale.key} gap="x1">
+          <HStack align="center" gap="x2">
+            <Box width="x14">
+              <Text color="fg.neutralSubtle" textStyle="t1Regular" maxLines={1}>
+                {scale.left}
+              </Text>
+            </Box>
+            <PatternTrack value={scale.value} />
+            <Box width="x14">
+              <Text align="right" color="fg.neutralSubtle" textStyle="t1Regular" maxLines={1}>
+                {scale.right}
+              </Text>
+            </Box>
+          </HStack>
+          {/* Interpretation slot: reserved for a future one-line reading. The
+              payload type carries no such field today, so nothing renders. */}
+        </VStack>
+      ))}
     </VStack>
   );
 }

--- a/src/data/media/interviewMediaUpload.ts
+++ b/src/data/media/interviewMediaUpload.ts
@@ -2,6 +2,7 @@ import { File } from 'expo-file-system';
 import type { SQLiteDatabase } from 'expo-sqlite';
 
 import { supabase } from '../../lib/supabase';
+import { mediaSpecForExtension } from '../../domain/interviewMedia';
 import {
   getInterviewAnswerById,
   getPendingMediaAnswers,
@@ -14,13 +15,8 @@ import { pushUnsyncedInterviewAnswers } from '../sync/interviewAnswersSync';
 import { deleteRecording } from './interviewRecordingFiles';
 
 const MEDIA_BUCKET = 'interview-media';
-const MEDIA_CONTENT_TYPE = 'audio/mp4';
 
 const inFlightAnswerIds = new Set<string>();
-
-function storagePath(userId: string, row: InterviewAnswerRow) {
-  return `${userId}/${row.sessionId}/${row.questionId}.m4a`;
-}
 
 async function uploadSingle(db: SQLiteDatabase, userId: string, row: InterviewAnswerRow) {
   if (inFlightAnswerIds.has(row.id)) {
@@ -41,11 +37,12 @@ async function uploadSingle(db: SQLiteDatabase, userId: string, row: InterviewAn
     }
 
     const bytes = await file.bytes();
-    const path = storagePath(userId, row);
+    const spec = mediaSpecForExtension(row.mediaLocalUri ?? row.mediaPath ?? '');
+    const path = `${userId}/${row.sessionId}/${row.questionId}.${spec.extension}`;
 
     const { error: uploadError } = await supabase.storage
       .from(MEDIA_BUCKET)
-      .upload(path, bytes.buffer as ArrayBuffer, { contentType: MEDIA_CONTENT_TYPE, upsert: true });
+      .upload(path, bytes.buffer as ArrayBuffer, { contentType: spec.contentType, upsert: true });
     if (uploadError) {
       if (__DEV__) {
         console.warn('[interviewMediaUpload] storage upload failed:', row.id, uploadError.message);

--- a/src/data/media/interviewRecordingFiles.ts
+++ b/src/data/media/interviewRecordingFiles.ts
@@ -1,5 +1,7 @@
 import { Directory, File, Paths } from 'expo-file-system';
 
+import type { MediaSpec } from '../../domain/interviewMedia';
+
 const ROOT_DIR = 'interview-media';
 
 function sessionDirectory(sessionDraftId: string) {
@@ -12,11 +14,12 @@ export async function persistRecording(
   sessionDraftId: string,
   questionId: string,
   cacheUri: string,
+  spec: MediaSpec,
 ) {
   const directory = sessionDirectory(sessionDraftId);
   directory.create({ intermediates: true, idempotent: true });
 
-  const target = new File(directory, `${questionId}.m4a`);
+  const target = new File(directory, `${questionId}.${spec.extension}`);
   const source = new File(cacheUri);
   await source.move(target, { overwrite: true });
 

--- a/src/data/server/useMockExamReport.ts
+++ b/src/data/server/useMockExamReport.ts
@@ -24,6 +24,8 @@ export type ReportSectionStates = {
   overall: ReportSectionState;
   competencies: ReportSectionState;
   highlights: ReportSectionState;
+  resilience: ReportSectionState;
+  pattern: ReportSectionState;
   coach: ReportSectionState;
   interview: ReportSectionState;
 };
@@ -34,6 +36,8 @@ export function getReportSectionStates(row: MockExamReportRow | null): ReportSec
       overall: 'pending',
       competencies: 'pending',
       highlights: 'pending',
+      resilience: 'pending',
+      pattern: 'pending',
       coach: 'pending',
       interview: 'pending',
     };
@@ -43,6 +47,8 @@ export function getReportSectionStates(row: MockExamReportRow | null): ReportSec
       overall: 'failed',
       competencies: 'failed',
       highlights: 'failed',
+      resilience: 'failed',
+      pattern: 'failed',
       coach: 'failed',
       interview: 'failed',
     };
@@ -63,6 +69,8 @@ export function getReportSectionStates(row: MockExamReportRow | null): ReportSec
     overall: r?.overall != null ? 'ready' : 'pending',
     competencies: r?.competencies != null ? 'ready' : 'pending',
     highlights: r?.highlights != null ? 'ready' : 'pending',
+    resilience: r?.resilience != null ? 'ready' : 'pending',
+    pattern: r?.response_pattern != null ? 'ready' : 'pending',
     coach: r?.coach != null ? 'ready' : 'pending',
     interview: interviewState,
   };
@@ -75,8 +83,9 @@ function computeRefetchInterval(
   if (row?.status === 'failed') return false;
   if (row?.status === 'done' && row.report != null) {
     const states = getReportSectionStates(row);
-    const allSectionsReady = Object.values(states).every((state) => state !== 'pending');
-    if (allSectionsReady && row.report.interview?.status !== 'pending') {
+    const CORE_KEYS = ['overall', 'competencies', 'highlights', 'coach'] as const;
+    const coreReady = CORE_KEYS.every((k) => states[k] !== 'pending');
+    if (coreReady && row.report.interview?.status !== 'pending') {
       return false;
     }
   }

--- a/src/data/server/useProfile.ts
+++ b/src/data/server/useProfile.ts
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { useAuth } from '../../providers/AuthProvider';
 import { supabase } from '../../lib/supabase';
+import type { BirthYearBand } from '../../domain/birthYearBand';
 import type { JobFamily } from '../../domain/report';
 
 export const profileKeys = {
@@ -13,6 +14,8 @@ export type ProfileRow = {
   id: string;
   field: JobFamily | null;
   onboardedAt: string | null;
+  birthYearBand: BirthYearBand | null;
+  birthYearBandConsentAt: string | null;
 };
 
 export function useProfile() {
@@ -26,7 +29,7 @@ export function useProfile() {
       }
       const { data, error } = await supabase
         .from('profiles')
-        .select('id, field, onboarded_at')
+        .select('id, field, onboarded_at, birth_year_band, birth_year_band_consent_at')
         .eq('id', userId)
         .maybeSingle();
       if (error) throw error;
@@ -35,10 +38,18 @@ export function useProfile() {
         id: data.id as string,
         field: (data.field as JobFamily) ?? null,
         onboardedAt: (data.onboarded_at as string | null) ?? null,
+        birthYearBand: (data.birth_year_band as BirthYearBand) ?? null,
+        birthYearBandConsentAt: (data.birth_year_band_consent_at as string | null) ?? null,
       };
     },
     enabled: userId != null,
   });
+}
+
+// Single future plug-in point for Pro entitlement. Returns a constant for now.
+export function useIsPro(): boolean {
+  // TODO: wire to real entitlement (no pro/premium field exists yet)
+  return false;
 }
 
 export function useUpdateProfile() {
@@ -46,13 +57,23 @@ export function useUpdateProfile() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (updates: Partial<{ field: JobFamily; onboardedAt: string }>) => {
+    mutationFn: async (
+      updates: Partial<{
+        field: JobFamily;
+        onboardedAt: string;
+        birthYearBand: BirthYearBand | null;
+        birthYearBandConsentAt: string | null;
+      }>,
+    ) => {
       if (!userId) {
         throw new Error('Cannot update profile without an authenticated user.');
       }
       const payload: Record<string, unknown> = {};
       if (updates.field !== undefined) payload.field = updates.field;
       if (updates.onboardedAt !== undefined) payload.onboarded_at = updates.onboardedAt;
+      if (updates.birthYearBand !== undefined) payload.birth_year_band = updates.birthYearBand;
+      if (updates.birthYearBandConsentAt !== undefined)
+        payload.birth_year_band_consent_at = updates.birthYearBandConsentAt;
       if (Object.keys(payload).length === 0) return;
 
       const { error } = await supabase

--- a/src/domain/birthYearBand.ts
+++ b/src/domain/birthYearBand.ts
@@ -1,0 +1,38 @@
+export type BirthYearBand =
+  | '~1969'
+  | '1970_1974'
+  | '1975_1979'
+  | '1980_1984'
+  | '1985_1989'
+  | '1990_1994'
+  | '1995_1999'
+  | '2000_2004'
+  | '2005_2009'
+  | '2010~';
+
+export type BirthYearBandOption = {
+  value: BirthYearBand;
+  label: string;
+};
+
+export const BIRTH_YEAR_BAND_OPTIONS: readonly BirthYearBandOption[] = [
+  { value: '~1969', label: '1969년 이전' },
+  { value: '1970_1974', label: '1970–1974년' },
+  { value: '1975_1979', label: '1975–1979년' },
+  { value: '1980_1984', label: '1980–1984년' },
+  { value: '1985_1989', label: '1985–1989년' },
+  { value: '1990_1994', label: '1990–1994년' },
+  { value: '1995_1999', label: '1995–1999년' },
+  { value: '2000_2004', label: '2000–2004년' },
+  { value: '2005_2009', label: '2005–2009년' },
+  { value: '2010~', label: '2010년 이후' },
+] as const;
+
+const BIRTH_YEAR_BAND_LABELS = Object.fromEntries(
+  BIRTH_YEAR_BAND_OPTIONS.map((option) => [option.value, option.label]),
+) as Record<BirthYearBand, string>;
+
+export function birthYearBandLabel(band: BirthYearBand | null | undefined): string | null {
+  if (band == null) return null;
+  return BIRTH_YEAR_BAND_LABELS[band] ?? null;
+}

--- a/src/domain/interviewMedia.ts
+++ b/src/domain/interviewMedia.ts
@@ -1,0 +1,15 @@
+export type MediaKind = 'audio' | 'video';
+
+export type MediaSpec = {
+  kind: MediaKind;
+  extension: 'm4a' | 'mp4';
+  contentType: string;
+};
+
+export const AUDIO_SPEC: MediaSpec = { kind: 'audio', extension: 'm4a', contentType: 'audio/mp4' };
+export const VIDEO_SPEC: MediaSpec = { kind: 'video', extension: 'mp4', contentType: 'video/mp4' };
+
+// Resolves a media spec from a stored file path/uri: '.mp4' → video, else audio.
+export function mediaSpecForExtension(path: string): MediaSpec {
+  return path.endsWith('.mp4') ? VIDEO_SPEC : AUDIO_SPEC;
+}

--- a/src/screens/InterviewFlowScreen.tsx
+++ b/src/screens/InterviewFlowScreen.tsx
@@ -243,9 +243,15 @@ export function InterviewFlowScreen() {
   // cap). A native auto-stop would resolve the promise with nothing consuming it,
   // leaving the UI stuck in 'rec'.
   function beginVideoRecording() {
+    const camera = cameraRef.current;
+    if (!camera || typeof camera.recordAsync !== 'function') {
+      Alert.alert('녹음을 시작하지 못했어요', '잠시 후 다시 시도해주세요.');
+      return;
+    }
+
     try {
       // recordAsync resolves only when recording stops — stash the promise.
-      recordingPromiseRef.current = cameraRef.current?.recordAsync() ?? null;
+      recordingPromiseRef.current = camera.recordAsync();
     } catch {
       Alert.alert('녹음을 시작하지 못했어요', '잠시 후 다시 시도해주세요.');
       return;
@@ -293,7 +299,7 @@ export function InterviewFlowScreen() {
     try {
       if (mediaSpec.kind === 'video') {
         cameraRef.current?.stopRecording();
-        const result = await recordingPromiseRef.current;
+        const result = await recordingPromiseRef.current!;
         recordingPromiseRef.current = null;
         const cacheUri = result?.uri;
         if (cacheUri) {

--- a/src/screens/InterviewFlowScreen.tsx
+++ b/src/screens/InterviewFlowScreen.tsx
@@ -8,6 +8,11 @@ import {
   setAudioModeAsync,
   useAudioRecorder,
 } from 'expo-audio';
+import {
+  type CameraView,
+  useCameraPermissions,
+  useMicrophonePermissions,
+} from 'expo-camera';
 import { useSQLiteContext } from 'expo-sqlite';
 
 import { Header } from '../components/app/Header';
@@ -27,7 +32,8 @@ import {
   deleteSessionRecordings,
   persistRecording,
 } from '../data/media/interviewRecordingFiles';
-import { useProfile } from '../data/server/useProfile';
+import { useIsPro, useProfile } from '../data/server/useProfile';
+import { AUDIO_SPEC, VIDEO_SPEC } from '../domain/interviewMedia';
 import type { JobPostingRow } from '../data/server/useJobPostings';
 import type { ResumeRow } from '../data/server/useResumes';
 import { useAuth } from '../providers/AuthProvider';
@@ -69,9 +75,13 @@ export function InterviewFlowScreen() {
   const isMockExamMode = mockExamId != null;
 
   const profile = useProfile();
+  const isPro = useIsPro();
+  const mediaSpec = isPro ? VIDEO_SPEC : AUDIO_SPEC;
   const saveInterviewOutcome = useSaveInterviewOutcome();
   const completeMockExamInterviewItem = useCompleteMockExamInterviewItem();
   const recorder = useAudioRecorder(RecordingPresets.HIGH_QUALITY);
+  const [, requestCameraPermission] = useCameraPermissions();
+  const [, requestMicrophonePermission] = useMicrophonePermissions();
 
   const [phase, setPhase] = useState<FlowPhase>('setup');
   const [selectedPosting, setSelectedPosting] = useState<JobPostingRow | null>(null);
@@ -85,6 +95,7 @@ export function InterviewFlowScreen() {
   const [recordMode, setRecordMode] = useState<RecordMode>('ready');
   const [elapsed, setElapsed] = useState(0);
   const [totalSeconds, setTotalSeconds] = useState(0);
+  const [reviewUri, setReviewUri] = useState<string | null>(null);
 
   const [sessionDraftId] = useState(() => Crypto.randomUUID());
   const flowStartedAtRef = useRef<number>(0);
@@ -92,6 +103,8 @@ export function InterviewFlowScreen() {
   const recordStartRef = useRef<number>(0);
   const answersRef = useRef<AnswerDraft[]>([]);
   const audioModeReadyRef = useRef(false);
+  const cameraRef = useRef<CameraView | null>(null);
+  const recordingPromiseRef = useRef<Promise<{ uri: string } | undefined> | null>(null);
 
   const currentQuestion = questions[questionIndex] ?? null;
 
@@ -109,7 +122,13 @@ export function InterviewFlowScreen() {
           style: 'destructive',
           onPress: () => {
             void (async () => {
-              if (recorder.isRecording) {
+              if (mediaSpec.kind === 'video') {
+                try {
+                  cameraRef.current?.stopRecording();
+                } catch {
+                  // ignore — best effort
+                }
+              } else if (recorder.isRecording) {
                 try {
                   await recorder.stop();
                 } catch {
@@ -123,7 +142,7 @@ export function InterviewFlowScreen() {
         },
       ]);
     });
-  }, [navigation, phase, recorder, sessionDraftId]);
+  }, [navigation, phase, recorder, sessionDraftId, mediaSpec.kind]);
 
   useEffect(() => {
     if (phase !== 'record' || recordMode !== 'rec') {
@@ -157,13 +176,24 @@ export function InterviewFlowScreen() {
 
     setStarting(true);
     try {
-      const permission = await AudioModule.requestRecordingPermissionsAsync();
-      if (!permission.granted) {
-        setMicDenied(true);
-        setCanAskMicAgain(permission.canAskAgain ?? false);
-        return;
+      if (mediaSpec.kind === 'video') {
+        const camera = await requestCameraPermission();
+        const microphone = await requestMicrophonePermission();
+        if (!camera.granted || !microphone.granted) {
+          setMicDenied(true);
+          setCanAskMicAgain((camera.canAskAgain ?? false) && (microphone.canAskAgain ?? false));
+          return;
+        }
+        setMicDenied(false);
+      } else {
+        const permission = await AudioModule.requestRecordingPermissionsAsync();
+        if (!permission.granted) {
+          setMicDenied(true);
+          setCanAskMicAgain(permission.canAskAgain ?? false);
+          return;
+        }
+        setMicDenied(false);
       }
-      setMicDenied(false);
 
       const jobFamily: JobFamily =
         selectedPosting.jobFamily ?? profile.data?.field ?? 'etc';
@@ -188,6 +218,17 @@ export function InterviewFlowScreen() {
   }
 
   async function requestMicAgain() {
+    if (mediaSpec.kind === 'video') {
+      const camera = await requestCameraPermission();
+      const microphone = await requestMicrophonePermission();
+      if (camera.granted && microphone.granted) {
+        setMicDenied(false);
+      } else {
+        setCanAskMicAgain((camera.canAskAgain ?? false) && (microphone.canAskAgain ?? false));
+      }
+      return;
+    }
+
     const permission = await AudioModule.requestRecordingPermissionsAsync();
     if (permission.granted) {
       setMicDenied(false);
@@ -196,8 +237,33 @@ export function InterviewFlowScreen() {
     }
   }
 
+  // Shared by startRecording and retakeAnswer — the video start is identical for
+  // both (re-record overwrites the same {questionId}.mp4). No maxDuration: matches
+  // the audio path's advisory limit (the on-screen 권장 시간 is guidance, not a hard
+  // cap). A native auto-stop would resolve the promise with nothing consuming it,
+  // leaving the UI stuck in 'rec'.
+  function beginVideoRecording() {
+    try {
+      // recordAsync resolves only when recording stops — stash the promise.
+      recordingPromiseRef.current = cameraRef.current?.recordAsync() ?? null;
+    } catch {
+      Alert.alert('녹음을 시작하지 못했어요', '잠시 후 다시 시도해주세요.');
+      return;
+    }
+
+    recordStartRef.current = Date.now();
+    setElapsed(0);
+    setReviewUri(null);
+    setRecordMode('rec');
+  }
+
   async function startRecording() {
     if (!currentQuestion) {
+      return;
+    }
+
+    if (mediaSpec.kind === 'video') {
+      beginVideoRecording();
       return;
     }
 
@@ -225,10 +291,30 @@ export function InterviewFlowScreen() {
 
     let mediaLocalUri: string | null = null;
     try {
-      await recorder.stop();
-      const cacheUri = recorder.uri;
-      if (cacheUri) {
-        mediaLocalUri = await persistRecording(sessionDraftId, currentQuestion.id, cacheUri);
+      if (mediaSpec.kind === 'video') {
+        cameraRef.current?.stopRecording();
+        const result = await recordingPromiseRef.current;
+        recordingPromiseRef.current = null;
+        const cacheUri = result?.uri;
+        if (cacheUri) {
+          mediaLocalUri = await persistRecording(
+            sessionDraftId,
+            currentQuestion.id,
+            cacheUri,
+            VIDEO_SPEC,
+          );
+        }
+      } else {
+        await recorder.stop();
+        const cacheUri = recorder.uri;
+        if (cacheUri) {
+          mediaLocalUri = await persistRecording(
+            sessionDraftId,
+            currentQuestion.id,
+            cacheUri,
+            AUDIO_SPEC,
+          );
+        }
       }
     } catch {
       mediaLocalUri = null;
@@ -254,11 +340,17 @@ export function InterviewFlowScreen() {
     }
 
     setTotalSeconds((current) => current + Math.round(answerMs / 1000));
+    setReviewUri(mediaLocalUri);
     setRecordMode('review');
   }
 
   async function retakeAnswer() {
     if (!currentQuestion) {
+      return;
+    }
+
+    if (mediaSpec.kind === 'video') {
+      beginVideoRecording();
       return;
     }
 
@@ -287,6 +379,7 @@ export function InterviewFlowScreen() {
     setQuestionIndex((current) => current + 1);
     setRecordMode('ready');
     setElapsed(0);
+    setReviewUri(null);
   }
 
   async function openFeedback() {
@@ -377,6 +470,7 @@ export function InterviewFlowScreen() {
         <InterviewSetupView
           selectedPosting={selectedPosting}
           selectedResume={selectedResume}
+          mediaKind={mediaSpec.kind}
           micDenied={micDenied}
           canAskMicAgain={canAskMicAgain}
           starting={starting}
@@ -394,6 +488,9 @@ export function InterviewFlowScreen() {
             total={questions.length}
             mode={recordMode}
             elapsed={elapsed}
+            kind={mediaSpec.kind}
+            cameraRef={cameraRef}
+            reviewUri={reviewUri}
             onStart={startRecording}
             onStop={stopRecording}
             onRetake={retakeAnswer}

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -4,71 +4,102 @@ import { Pressable } from 'react-native';
 import { Screen } from '../components/app/Screen';
 import { Button } from '../components/ui/Button';
 import { Icon } from '../components/ui/Icon';
+import { Switch } from '../components/ui/Switch';
 import { useUpdateProfile } from '../data/server/useProfile';
 import { Box } from '../design-system/components/Box';
 import { Grid } from '../design-system/components/Grid';
-import { VStack } from '../design-system/components/Stack';
+import { HStack, VStack } from '../design-system/components/Stack';
 import { Text } from '../design-system/components/Text';
+import { BIRTH_YEAR_BAND_OPTIONS, type BirthYearBand } from '../domain/birthYearBand';
 import { JOB_FAMILY_OPTIONS } from '../domain/jobFamily';
 import type { JobFamily } from '../domain/report';
 
 export function OnboardingScreen() {
+  const [step, setStep] = useState<'field' | 'birth'>('field');
   const [selected, setSelected] = useState<JobFamily | null>(null);
+  const [band, setBand] = useState<BirthYearBand | null>(null);
+  const [consent, setConsent] = useState(false);
   const [hasError, setHasError] = useState(false);
   const updateProfile = useUpdateProfile();
 
-  function handleStart() {
+  function handleNext() {
+    if (selected == null) return;
+    setStep('birth');
+  }
+
+  function finish(includeBand: boolean) {
     if (selected == null || updateProfile.isPending) return;
     setHasError(false);
-    updateProfile.mutate(
-      { field: selected, onboardedAt: new Date().toISOString() },
-      { onError: () => setHasError(true) },
-    );
+    const now = new Date().toISOString();
+    const updates =
+      includeBand && consent && band != null
+        ? { field: selected, onboardedAt: now, birthYearBand: band, birthYearBandConsentAt: now }
+        : { field: selected, onboardedAt: now };
+    updateProfile.mutate(updates, { onError: () => setHasError(true) });
   }
 
   return (
     <Screen bg="bg.layerDefault">
       <VStack flex={1} gap="x6">
         <VStack flex={1} gap="x5">
-          <VStack gap="x2">
-            <Text textStyle="screenTitle">어떤 직무를{'\n'}준비하고 있나요?</Text>
-            <Text color="fg.neutralMuted" textStyle="t4Regular">
-              선택한 직무에 맞춰 면접 질문과 리포트를 준비해 드려요.
-            </Text>
-          </VStack>
+          {step === 'field' ? (
+            <>
+              <VStack gap="x2">
+                <Text textStyle="screenTitle">어떤 직무를{'\n'}준비하고 있나요?</Text>
+                <Text color="fg.neutralMuted" textStyle="t4Regular">
+                  선택한 직무에 맞춰 면접 질문과 리포트를 준비해 드려요.
+                </Text>
+              </VStack>
 
-          <Grid columns={2} gap="x2">
-            {JOB_FAMILY_OPTIONS.map((option) => {
-              const isSelected = option.value === selected;
-              return (
-                <Pressable
-                  key={option.value}
-                  accessibilityRole="radio"
-                  accessibilityState={{ selected: isSelected }}
-                  onPress={() => setSelected(option.value)}
-                >
-                  <VStack
-                    align="flexStart"
-                    bg={isSelected ? 'bg.brandWeak' : 'bg.layerFloating'}
-                    borderColor={isSelected ? 'stroke.brandWeak' : 'stroke.neutralWeak'}
-                    borderRadius="r4"
-                    borderWidth="thin"
-                    gap="x3"
+              <Grid columns={2} gap="x2">
+                {JOB_FAMILY_OPTIONS.map((option) => (
+                  <OnboardingOptionCard
+                    key={option.value}
+                    label={option.label}
+                    selected={option.value === selected}
                     minHeight="x23"
-                    p="x4"
-                  >
-                    <Icon
-                      name={isSelected ? 'CircleCheck' : 'Circle'}
-                      color={isSelected ? 'fg.brand' : 'fg.neutralSubtle'}
-                    />
-                    <Text color={isSelected ? 'fg.brand' : 'fg.neutral'} textStyle="t5Bold" maxLines={2}>
-                      {option.label}
-                    </Text>
-                  </VStack>
-                </Pressable>
-              );
-            })}
-          </Grid>
+                    maxLines={2}
+                    onPress={() => setSelected(option.value)}
+                  />
+                ))}
+              </Grid>
+            </>
+          ) : (
+            <>
+              <VStack gap="x2">
+                <Text textStyle="screenTitle">태어난 시기를{'\n'}알려주실래요?</Text>
+                <Text color="fg.neutralMuted" textStyle="t4Regular">
+                  비슷한 또래와 비교한 결과를 리포트에서 보여드릴 때 사용해요. 입력하지 않아도 괜찮아요.
+                </Text>
+              </VStack>
+
+              <Grid columns={2} gap="x2">
+                {BIRTH_YEAR_BAND_OPTIONS.map((option) => (
+                  <OnboardingOptionCard
+                    key={option.value}
+                    label={option.label}
+                    selected={option.value === band}
+                    minHeight="x16"
+                    maxLines={1}
+                    onPress={() => setBand(option.value)}
+                  />
+                ))}
+              </Grid>
+
+              <HStack align="center" gap="x3">
+                <Box flex={1}>
+                  <Text color="fg.neutral" textStyle="t3Regular">
+                    또래 비교를 위해 출생 연도 정보를 사용하는 데 동의해요.
+                  </Text>
+                </Box>
+                <Switch
+                  label="또래 비교를 위해 출생 연도 정보를 사용하는 데 동의해요."
+                  value={consent}
+                  onPress={() => setConsent((enabled) => !enabled)}
+                />
+              </HStack>
+            </>
+          )}
         </VStack>
 
         <VStack gap="x2" pb="x4">
@@ -79,16 +110,92 @@ export function OnboardingScreen() {
               </Text>
             ) : null}
           </Box>
-          <Button
-            label={updateProfile.isPending ? '저장하는 중...' : '시작하기'}
-            variant="solid"
-            tone="brand"
-            fullWidth
-            disabled={selected == null || updateProfile.isPending}
-            onPress={handleStart}
-          />
+          {step === 'field' ? (
+            <Button
+              label="다음"
+              variant="solid"
+              tone="brand"
+              fullWidth
+              disabled={selected == null}
+              onPress={handleNext}
+            />
+          ) : (
+            <VStack gap="x2">
+              <Button
+                label={updateProfile.isPending ? '저장하는 중...' : '시작하기'}
+                variant="solid"
+                tone="brand"
+                fullWidth
+                disabled={!consent || band == null || updateProfile.isPending}
+                onPress={() => finish(true)}
+              />
+              <HStack gap="x2">
+                <Box flex={1}>
+                  <Button
+                    label="이전"
+                    variant="ghost"
+                    tone="neutral"
+                    fullWidth
+                    disabled={updateProfile.isPending}
+                    onPress={() => setStep('field')}
+                  />
+                </Box>
+                <Box flex={1}>
+                  <Button
+                    label="건너뛰기"
+                    variant="ghost"
+                    tone="neutral"
+                    fullWidth
+                    disabled={updateProfile.isPending}
+                    onPress={() => finish(false)}
+                  />
+                </Box>
+              </HStack>
+            </VStack>
+          )}
         </VStack>
       </VStack>
     </Screen>
+  );
+}
+
+function OnboardingOptionCard({
+  label,
+  selected,
+  minHeight,
+  maxLines,
+  onPress,
+}: {
+  label: string;
+  selected: boolean;
+  minHeight: 'x23' | 'x16';
+  maxLines: number;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      accessibilityRole="radio"
+      accessibilityState={{ selected }}
+      onPress={onPress}
+    >
+      <VStack
+        align="flexStart"
+        bg={selected ? 'bg.brandWeak' : 'bg.layerFloating'}
+        borderColor={selected ? 'stroke.brandWeak' : 'stroke.neutralWeak'}
+        borderRadius="r4"
+        borderWidth="thin"
+        gap="x3"
+        minHeight={minHeight}
+        p="x4"
+      >
+        <Icon
+          name={selected ? 'CircleCheck' : 'Circle'}
+          color={selected ? 'fg.brand' : 'fg.neutralSubtle'}
+        />
+        <Text color={selected ? 'fg.brand' : 'fg.neutral'} textStyle="t5Bold" maxLines={maxLines}>
+          {label}
+        </Text>
+      </VStack>
+    </Pressable>
   );
 }

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -4,6 +4,7 @@ import { Alert } from 'react-native';
 import { Header } from '../components/app/Header';
 import { SectionHead } from '../components/app/SectionHead';
 import { TabScreen } from '../components/app/TabScreen';
+import { BirthYearBandSheet } from '../components/profile/BirthYearBandSheet';
 import { JobFamilySheet } from '../components/profile/JobFamilySheet';
 import { ProfileSummary } from '../components/profile/ProfileSummary';
 import { StatTile } from '../components/profile/StatTile';
@@ -19,6 +20,7 @@ import { useClearDevData, useSeedDevData } from '../data/seed/useSeedDevData';
 import { user } from '../data/user';
 import { HStack, VStack } from '../design-system/components/Stack';
 import { Text } from '../design-system/components/Text';
+import { birthYearBandLabel } from '../domain/birthYearBand';
 import { jobFamilyLabel } from '../domain/jobFamily';
 import { IdentityConflictError, linkKakao } from '../lib/auth';
 import { supabase } from '../lib/supabase';
@@ -31,6 +33,7 @@ export function ProfileScreen() {
   const [isLinking, setIsLinking] = useState(false);
   const [isSigningOut, setIsSigningOut] = useState(false);
   const [jobFamilyVisible, setJobFamilyVisible] = useState(false);
+  const [birthBandVisible, setBirthBandVisible] = useState(false);
   const { data: profile } = useProfile();
   const gamesWithProgress = useGamesWithProgress();
   const doneCount = gamesWithProgress.filter((game) => game.status === 'done').length;
@@ -113,12 +116,33 @@ export function ProfileScreen() {
               </HStack>
             </List.Suffix>
           </List.Item>
+          <List.Item onPress={() => setBirthBandVisible(true)}>
+            <List.Prefix>
+              <Icon name="Timeline" color="fg.brand" />
+            </List.Prefix>
+            <List.Content>
+              <List.Title>출생 연도</List.Title>
+            </List.Content>
+            <List.Suffix>
+              <HStack align="center" gap="x1">
+                <Text color="fg.neutralMuted" textStyle="t3Medium" maxLines={1}>
+                  {birthYearBandLabel(profile?.birthYearBand) ?? '비공개'}
+                </Text>
+                <Icon name="ChevronRight" size="small" />
+              </HStack>
+            </List.Suffix>
+          </List.Item>
         </List.Root>
       </Card>
       <JobFamilySheet
         visible={jobFamilyVisible}
         current={profile?.field ?? null}
         onClose={() => setJobFamilyVisible(false)}
+      />
+      <BirthYearBandSheet
+        visible={birthBandVisible}
+        current={profile?.birthYearBand ?? null}
+        onClose={() => setBirthBandVisible(false)}
       />
 
       <SectionHead title="설정" />

--- a/src/screens/ReportDetailScreen.tsx
+++ b/src/screens/ReportDetailScreen.tsx
@@ -11,7 +11,7 @@ import { FeedbackReportBody } from '../components/interview/FeedbackReportBody';
 import { AnalysisStatusCard } from '../components/reports/AnalysisStatusCard';
 import { CompetencySection } from '../components/reports/CompetencySection';
 import { GamesSection } from '../components/reports/GamesSection';
-import { GrowthTrendChart, PercentileBar } from '../components/reports/ReportCharts';
+import { GrowthTrendChart, PercentileBar, ResponsePatternRows, StressResilienceChart } from '../components/reports/ReportCharts';
 import { Button } from '../components/ui/Button';
 import { Card } from '../components/ui/Card';
 import { Icon } from '../components/ui/Icon';
@@ -40,6 +40,8 @@ import type {
   ReportCompetencyScore,
   ReportHighlights,
   ReportOverall,
+  ReportResilience,
+  ReportResponsePattern,
 } from '../domain/report';
 import type { MockExamRecord, ReportSectionKey } from '../domain/types';
 import type { ReportSectionStates } from '../data/server/useMockExamReport';
@@ -341,9 +343,9 @@ function ReportSectionBody({
     case 'interview':
       return <InterviewFeedbackSection mockExamId={record.id} report={report} state={states.interview} />;
     case 'resilience':
-      return <AnalysisStatusCard variant="pending" />;
+      return <ResilienceSection resilience={report?.resilience ?? null} state={states.resilience} onRetry={onRetryReport} />;
     case 'pattern':
-      return <AnalysisStatusCard variant="pending" />;
+      return <ResponsePatternSection pattern={report?.response_pattern ?? null} state={states.pattern} onRetry={onRetryReport} />;
     case 'peer':
       return <GrowthSection record={record} records={records} overall={report?.overall ?? null} />;
     case 'coach':
@@ -559,6 +561,76 @@ function CompetenciesSection({ competencies, state, onRetry }: CompetenciesSecti
     return <AnalysisStatusCard variant="pending" minHeight="x60" />;
   }
   return <CompetencySection competencies={competencies} />;
+}
+
+type ResilienceSectionProps = {
+  resilience: ReportResilience;
+  state: ReportSectionStates['resilience'];
+  onRetry: () => void;
+};
+
+function ResilienceSection({ resilience, state, onRetry }: ResilienceSectionProps) {
+  if (state === 'failed') {
+    return <AnalysisStatusCard variant="failed" minHeight="x60" onRetry={onRetry} />;
+  }
+  if (resilience == null || state !== 'ready') {
+    return <AnalysisStatusCard variant="pending" minHeight="x60" />;
+  }
+
+  const insights = resilience.insights.slice(0, 2);
+
+  return (
+    <VStack gap="x3">
+      <Card>
+        <VStack gap="x2">
+          <StressResilienceChart values={resilience.curve.map((point) => point.value)} />
+          <HStack justify="spaceBetween">
+            {resilience.curve.map((point, index) => (
+              <Text
+                key={`${point.game_id}-${index}`}
+                color="fg.neutralSubtle"
+                textStyle="t1Regular"
+                maxLines={1}
+              >
+                {gameNameFor(point.game_id)}
+              </Text>
+            ))}
+          </HStack>
+        </VStack>
+      </Card>
+      <Grid columns={2} gap="x2">
+        {insights.map((insight, index) => (
+          <InsightTile
+            key={`${insight.label}-${index}`}
+            label={insight.label}
+            title={insight.title}
+            description={insight.body}
+            tone={insight.tone === 'positive' ? 'positive' : 'warning'}
+          />
+        ))}
+      </Grid>
+    </VStack>
+  );
+}
+
+type ResponsePatternSectionProps = {
+  pattern: ReportResponsePattern;
+  state: ReportSectionStates['pattern'];
+  onRetry: () => void;
+};
+
+function ResponsePatternSection({ pattern, state, onRetry }: ResponsePatternSectionProps) {
+  if (state === 'failed') {
+    return <AnalysisStatusCard variant="failed" minHeight="x60" onRetry={onRetry} />;
+  }
+  if (pattern == null || pattern.scales.length === 0 || state !== 'ready') {
+    return <AnalysisStatusCard variant="pending" minHeight="x60" />;
+  }
+  return (
+    <Card>
+      <ResponsePatternRows scales={pattern.scales} />
+    </Card>
+  );
 }
 
 type HighlightsSectionProps = {

--- a/src/screens/interview/InterviewStepViews.tsx
+++ b/src/screens/interview/InterviewStepViews.tsx
@@ -1,3 +1,6 @@
+import { type RefObject } from 'react';
+import type { CameraView } from 'expo-camera';
+
 import { Body } from '../../components/app/Body';
 import { BottomActionBar } from '../../components/app/BottomActionBar';
 import {
@@ -17,6 +20,7 @@ import { Grid } from '../../design-system/components/Grid';
 import { HStack, VStack } from '../../design-system/components/Stack';
 import { Text } from '../../design-system/components/Text';
 import type { InterviewPromptQuestion } from '../../domain/composeInterviewQuestions';
+import type { MediaKind } from '../../domain/interviewMedia';
 
 export function RecordStepView({
   question,
@@ -24,6 +28,9 @@ export function RecordStepView({
   total,
   mode,
   elapsed,
+  kind,
+  cameraRef,
+  reviewUri,
   onStart,
   onStop,
   onRetake,
@@ -34,6 +41,9 @@ export function RecordStepView({
   total: number;
   mode: RecordMode;
   elapsed: number;
+  kind: MediaKind;
+  cameraRef: RefObject<CameraView | null>;
+  reviewUri: string | null;
   onStart: () => void;
   onStop: () => void;
   onRetake: () => void;
@@ -50,7 +60,15 @@ export function RecordStepView({
         </HStack>
         <Card p="x3">
           <HStack gap="x3">
-            <InterviewCameraView active recording={mode === 'rec'} elapsed={elapsed} />
+            <InterviewCameraView
+              active
+              recording={mode === 'rec'}
+              reviewing={mode === 'review'}
+              elapsed={elapsed}
+              kind={kind}
+              cameraRef={cameraRef}
+              reviewUri={reviewUri}
+            />
             <VStack flex={1} gap="x2">
               <Badge label={question.category} tone="brand" size="small" />
               <Text textStyle="t4Bold">{question.text}</Text>

--- a/supabase/migrations/20260613032903_add_profiles_birth_year_band.sql
+++ b/supabase/migrations/20260613032903_add_profiles_birth_year_band.sql
@@ -1,0 +1,14 @@
+-- Cohort definition input for peer percentiles (P2). Optional, consent-gated.
+-- The out-of-repo analysis server buckets users on these exact tokens;
+-- null birth_year_band = undisclosed / excluded from cohort.
+alter table "public"."profiles"
+  add column "birth_year_band" text
+    check (birth_year_band in (
+      '~1969', '1970_1974', '1975_1979', '1980_1984', '1985_1989',
+      '1990_1994', '1995_1999', '2000_2004', '2005_2009', '2010~'
+    ));
+
+-- Records when the user consented to using their birth-year band for peer
+-- comparison. Null = not consented. Timestamp (not boolean) keeps an audit trail.
+alter table "public"."profiles"
+  add column "birth_year_band_consent_at" timestamptz;

--- a/supabase/migrations/20260613032903_add_profiles_birth_year_band.sql
+++ b/supabase/migrations/20260613032903_add_profiles_birth_year_band.sql
@@ -12,3 +12,16 @@ alter table "public"."profiles"
 -- comparison. Null = not consented. Timestamp (not boolean) keeps an audit trail.
 alter table "public"."profiles"
   add column "birth_year_band_consent_at" timestamptz;
+
+alter table "public"."profiles"
+  add constraint "profiles_birth_year_band_pairing_chk"
+  check (
+    (
+      birth_year_band is null
+      and birth_year_band_consent_at is null
+    )
+    or (
+      birth_year_band is not null
+      and birth_year_band_consent_at is not null
+    )
+  );

--- a/supabase/migrations/20260613032904_add_video_to_interview_media_bucket.sql
+++ b/supabase/migrations/20260613032904_add_video_to_interview_media_bucket.sql
@@ -1,0 +1,12 @@
+-- P2 Pro-only interview video: the interview-media bucket previously allowed only
+-- audio MIME types and capped at 25 MiB, which would reject video/mp4 uploads.
+-- Widen the allowlist and raise the size limit. RLS policies are extension-agnostic
+-- and need no change.
+update storage.buckets
+set
+  allowed_mime_types = ARRAY[
+    'audio/mp4', 'audio/m4a', 'audio/x-m4a', 'audio/aac',
+    'video/mp4', 'video/quicktime'
+  ],
+  file_size_limit = 157286400  -- ~150 MiB
+where id = 'interview-media';


### PR DESCRIPTION
Add optional birth-year cohort capture, video interview recording support, and report sections for resilience and response patterns.

Constraint: Pro interview media and peer reports need consent-gated cohort data plus storage support for video uploads.

Confidence: high

Scope-risk: moderate

Directive: Keep birth-year cohort use optional and consent-gated; do not block interview gameplay on media sync.

Tested: not run in this commit step

Not-tested: typecheck, lint, runtime Expo flows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added video interview recording and playback capability alongside audio
  * Added birth year band field to user profile with privacy consent option
  * Added delivery details section to interview analysis results
  * Enhanced interview reports with stress resilience visualization and response pattern analysis

* **Chores**
  * Updated storage configuration to support video uploads
  * Added video playback dependency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->